### PR TITLE
Migrate to kotlinx.serialization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("dev.nevack.plugins.signing-config")
+    id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
     id("org.gradle.android.cache-fix")
@@ -66,12 +67,11 @@ dependencies {
     implementation("androidx.sqlite:sqlite:2.6.2")
     // Okio
     implementation("com.squareup.okio:okio:3.17.0")
-    // Moshi
-    implementation("com.squareup.moshi:moshi:1.15.2")
-    ksp("com.squareup.moshi:moshi-kotlin-codegen:1.15.2")
+    // Kotlinx serialization
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
     // Retrofit
     implementation("com.squareup.retrofit2:retrofit:3.0.0")
-    implementation("com.squareup.retrofit2:converter-moshi:3.0.0")
+    implementation("com.squareup.retrofit2:converter-kotlinx-serialization:3.0.0")
     // Insetter
     implementation("dev.chrisbanes.insetter:insetter:0.6.1")
     // Dagger + Hilt

--- a/app/src/main/kotlin/dev/nevack/unitconverter/DateJsonAdapter.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/DateJsonAdapter.kt
@@ -1,33 +1,30 @@
 package dev.nevack.unitconverter
 
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.JsonReader
-import com.squareup.moshi.JsonWriter
-import java.text.DateFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-class DateJsonAdapter : JsonAdapter<Date>() {
-    private var df: DateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+object DateJsonAdapter : KSerializer<Date> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("dev.nevack.unitconverter.DateJsonAdapter", PrimitiveKind.STRING)
 
-    override fun fromJson(reader: JsonReader): Date? {
-        if (reader.peek() == JsonReader.Token.NULL) {
-            return reader.nextNull()
+    private val formatter =
+        ThreadLocal.withInitial {
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
         }
-        val string = reader.nextString()
-        return df.parse(string)
-    }
 
-    override fun toJson(
-        writer: JsonWriter,
-        value: Date?,
+    override fun deserialize(decoder: Decoder): Date = formatter.get()!!.parse(decoder.decodeString())!!
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Date,
     ) {
-        if (value == null) {
-            writer.nullValue()
-        } else {
-            val string = df.format(value)
-            writer.value(string)
-        }
+        encoder.encodeString(formatter.get()!!.format(value))
     }
 }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/MainModule.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/MainModule.kt
@@ -1,7 +1,6 @@
 package dev.nevack.unitconverter
 
 import android.content.Context
-import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -9,27 +8,27 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dev.nevack.unitconverter.model.nbrb.NBRBCurrency
 import dev.nevack.unitconverter.model.nbrb.NBRBRepository
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.io.File
-import java.util.Date
 
 @Module
 @InstallIn(SingletonComponent::class)
 object MainModule {
     @Provides
-    fun provideMoshi(): Moshi =
-        Moshi
-            .Builder()
-            .add(Date::class.java, DateJsonAdapter())
-            .build()
+    fun provideJson(): Json =
+        Json {
+            ignoreUnknownKeys = true
+        }
 
     @Provides
-    fun provideRetrofit(moshi: Moshi): Retrofit =
+    fun provideRetrofit(json: Json): Retrofit =
         Retrofit
             .Builder()
             .baseUrl("https://api.nbrb.by/exrates/")
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
 
     @Provides
@@ -39,10 +38,10 @@ object MainModule {
     fun provideNBRBRepository(
         @ApplicationContext context: Context,
         service: NBRBService,
-        moshi: Moshi,
+        json: Json,
     ): NBRBRepository {
         val localeList = context.resources.configuration.locales
         val locale = NBRBCurrency.getCompatibleLocale(localeList)
-        return NBRBRepository(locale, { name -> File(context.filesDir, name) }, service, moshi)
+        return NBRBRepository(locale, { name -> File(context.filesDir, name) }, service, json)
     }
 }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/model/nbrb/NBRBCurrency.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/model/nbrb/NBRBCurrency.kt
@@ -1,46 +1,49 @@
 package dev.nevack.unitconverter.model.nbrb
 
 import android.os.LocaleList
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+import dev.nevack.unitconverter.DateJsonAdapter
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.Date
 import java.util.Locale
 
-@JsonClass(generateAdapter = true)
+@Serializable
 data class NBRBCurrency(
-    @Json(name = "Cur_Abbreviation")
+    @SerialName("Cur_Abbreviation")
     val curAbbreviation: String,
-    @Json(name = "Cur_Code")
+    @SerialName("Cur_Code")
     val curCode: String,
-    @Json(name = "Cur_DateEnd")
+    @SerialName("Cur_DateEnd")
+    @Serializable(with = DateJsonAdapter::class)
     val curDateEnd: Date,
-    @Json(name = "Cur_DateStart")
+    @SerialName("Cur_DateStart")
+    @Serializable(with = DateJsonAdapter::class)
     val curDateStart: Date,
-    @Json(name = "Cur_ID")
+    @SerialName("Cur_ID")
     val curID: Int,
-    @Json(name = "Cur_Name")
+    @SerialName("Cur_Name")
     val curName: String,
-    @Json(name = "Cur_Name_Bel")
+    @SerialName("Cur_Name_Bel")
     val curNameBel: String,
-    @Json(name = "Cur_Name_BelMulti")
+    @SerialName("Cur_Name_BelMulti")
     val curNameBelMulti: String,
-    @Json(name = "Cur_Name_Eng")
+    @SerialName("Cur_Name_Eng")
     val curNameEng: String,
-    @Json(name = "Cur_Name_EngMulti")
+    @SerialName("Cur_Name_EngMulti")
     val curNameEngMulti: String,
-    @Json(name = "Cur_NameMulti")
+    @SerialName("Cur_NameMulti")
     val curNameMulti: String,
-    @Json(name = "Cur_ParentID")
+    @SerialName("Cur_ParentID")
     val curParentID: Int,
-    @Json(name = "Cur_Periodicity")
+    @SerialName("Cur_Periodicity")
     val curPeriodicity: Int,
-    @Json(name = "Cur_QuotName")
+    @SerialName("Cur_QuotName")
     val curQuotName: String,
-    @Json(name = "Cur_QuotName_Bel")
+    @SerialName("Cur_QuotName_Bel")
     val curQuotNameBel: String,
-    @Json(name = "Cur_QuotName_Eng")
+    @SerialName("Cur_QuotName_Eng")
     val curQuotNameEng: String,
-    @Json(name = "Cur_Scale")
+    @SerialName("Cur_Scale")
     val curScale: Int,
 ) {
     companion object {

--- a/app/src/main/kotlin/dev/nevack/unitconverter/model/nbrb/NBRBRate.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/model/nbrb/NBRBRate.kt
@@ -1,23 +1,25 @@
 package dev.nevack.unitconverter.model.nbrb
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+import dev.nevack.unitconverter.DateJsonAdapter
 import dev.nevack.unitconverter.model.ConversionUnit
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.Date
 
-@JsonClass(generateAdapter = true)
+@Serializable
 data class NBRBRate(
-    @Json(name = "Cur_Abbreviation")
+    @SerialName("Cur_Abbreviation")
     val curAbbreviation: String,
-    @Json(name = "Cur_ID")
+    @SerialName("Cur_ID")
     val curID: Int,
-    @Json(name = "Cur_Name")
+    @SerialName("Cur_Name")
     val curName: String,
-    @Json(name = "Cur_OfficialRate")
+    @SerialName("Cur_OfficialRate")
     val curOfficialRate: Double,
-    @Json(name = "Cur_Scale")
+    @SerialName("Cur_Scale")
     val curScale: Int,
-    @Json(name = "Date")
+    @SerialName("Date")
+    @Serializable(with = DateJsonAdapter::class)
     val date: Date,
 ) {
     fun toUnitLocalized(name: String): ConversionUnit =

--- a/app/src/main/kotlin/dev/nevack/unitconverter/model/nbrb/NBRBRepository.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/model/nbrb/NBRBRepository.kt
@@ -1,16 +1,14 @@
 package dev.nevack.unitconverter.model.nbrb
 
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import dev.nevack.unitconverter.NBRBService
 import dev.nevack.unitconverter.model.ConversionUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
-import okio.buffer
-import okio.sink
-import okio.source
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 import java.io.File
 import java.io.IOException
 import java.util.Calendar
@@ -20,22 +18,22 @@ class NBRBRepository(
     private val locale: Locale,
     fileProvider: (String) -> File,
     private var service: NBRBService,
-    moshi: Moshi,
+    private val json: Json,
 ) {
     private val currenciesFile = fileProvider("currencies.json")
     private val ratesFile = fileProvider("rates.json")
-    private val ratesAdapter: JsonAdapter<List<NBRBRate>> = moshi.adapter(RATES_TYPE)
-    private val currenciesAdapter: JsonAdapter<List<NBRBCurrency>> = moshi.adapter(CURRENCIES_TYPE)
+    private val ratesSerializer = ListSerializer(NBRBRate.serializer())
+    private val currenciesSerializer = ListSerializer(NBRBCurrency.serializer())
 
     suspend fun getUnits(): List<ConversionUnit> =
         withContext(Dispatchers.IO) {
             val currenciesAsync =
                 async {
-                    loadWithCache(currenciesAdapter, currenciesFile) { allCurrencies() }
+                    loadWithCache(currenciesSerializer, currenciesFile) { allCurrencies() }
                 }
             val ratesAsync =
                 async {
-                    loadWithCache(ratesAdapter, ratesFile) { allRatesForToday() }
+                    loadWithCache(ratesSerializer, ratesFile) { allRatesForToday() }
                 }
             val currencies = currenciesAsync.await().associateBy { it.curID }
             val rates = ratesAsync.await()
@@ -45,7 +43,7 @@ class NBRBRepository(
         }
 
     private suspend fun <T> loadWithCache(
-        adapter: JsonAdapter<T>,
+        serializer: KSerializer<T>,
         file: File,
         block: suspend NBRBService.() -> T,
     ): T =
@@ -53,49 +51,43 @@ class NBRBRepository(
             if (file.exists()) {
                 val calendar = Calendar.getInstance().apply { timeInMillis = file.lastModified() }
                 if (Calendar.getInstance()[Calendar.DAY_OF_YEAR] == calendar[Calendar.DAY_OF_YEAR]) {
-                    val cached = adapter.load(file)
+                    val cached = serializer.load(file)
                     if (cached != null) {
                         return@withContext cached
                     }
                 }
             }
-            loadFromWeb(adapter, file, block)
+            loadFromWeb(serializer, file, block)
         }
 
     private suspend fun <T> loadFromWeb(
-        adapter: JsonAdapter<T>,
+        serializer: KSerializer<T>,
         cache: File,
         block: suspend NBRBService.() -> T,
     ): T =
         withContext(Dispatchers.IO) {
             val result = service.block()
-            adapter.save(result to cache)
+            serializer.save(result to cache)
             result
         }
 
-    private suspend fun <T> JsonAdapter<T>.save(what: Pair<T, File>) =
+    private suspend fun <T> KSerializer<T>.save(what: Pair<T, File>) =
         withContext(Dispatchers.IO) {
             try {
-                what.second
-                    .sink()
-                    .buffer()
-                    .use { sink -> toJson(sink, what.first) }
+                what.second.writeText(json.encodeToString(this@save, what.first))
             } catch (ignored: IOException) {
+            } catch (ignored: SerializationException) {
             }
         }
 
-    private suspend fun <T> JsonAdapter<T>.load(from: File): T? =
+    private suspend fun <T> KSerializer<T>.load(from: File): T? =
         withContext(Dispatchers.IO) {
             try {
-                from.source().buffer().use { source -> fromJson(source) }
-            } catch (e: IOException) {
+                json.decodeFromString(this@load, from.readText())
+            } catch (ignored: IOException) {
+                null
+            } catch (ignored: SerializationException) {
                 null
             }
         }
-
-    companion object {
-        private val RATES_TYPE = Types.newParameterizedType(List::class.java, NBRBRate::class.java)
-        private val CURRENCIES_TYPE =
-            Types.newParameterizedType(List::class.java, NBRBCurrency::class.java)
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.github.ben-manes.versions") apply false
     id("com.android.application") apply false
     id("org.jetbrains.kotlin.android") apply false
+    id("org.jetbrains.kotlin.plugin.serialization") apply false
     id("com.google.devtools.ksp") apply false
     id("com.google.dagger.hilt.android") apply false
     id("org.gradle.android.cache-fix") apply false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ pluginManagement {
         id("com.diffplug.spotless") version "8.4.0"
         id("com.android.application") version "9.2.0"
         id("org.jetbrains.kotlin.android") version "2.3.20"
+        id("org.jetbrains.kotlin.plugin.serialization") version "2.3.20"
         id("com.google.devtools.ksp") version "2.3.6"
         id("com.google.dagger.hilt.android") version "2.59.2"
         id("org.gradle.android.cache-fix") version "3.0.3"


### PR DESCRIPTION
Replace Moshi in the NBRB network and cache flow with kotlinx.serialization while preserving the cached JSON shape and date format.
