### PR TITLE
Refactor converter state around a single UI model

### DIFF
--- a/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
@@ -41,25 +41,23 @@ class ConverterActivity : AppCompatActivity() {
             onBackPressedDispatcher.addCallback(this) {
                 viewModel.setDrawerOpened(false)
             }
-        viewModel.drawerOpened.observe(this) { opened ->
-            callback.isEnabled = opened
-            if (opened) {
+        viewModel.uiState.observe(this) { state ->
+            callback.isEnabled = state.drawerOpened
+            if (state.drawerOpened) {
                 binding.navigationDrawer.open()
             } else {
                 binding.navigationDrawer.close()
+            }
+            val categoryId = state.categoryId ?: return@observe
+            val categoryIndex = catalog.categories.indexOfFirst { it.id == categoryId }
+            if (categoryIndex != -1) {
+                binding.navigationView.menu[categoryIndex].isChecked = true
             }
         }
 
         supportFragmentManager.commit {
             setReorderingAllowed(true)
             replace<ConverterFragment>(R.id.container, args = bundleOf(SHOW_NAV_BUTTON_ARG to true))
-        }
-
-        viewModel.categoryId.observe(this) { categoryId ->
-            val categoryIndex = catalog.categories.indexOfFirst { it.id == categoryId }
-            if (categoryIndex != -1) {
-                binding.navigationView.menu[categoryIndex].isChecked = true
-            }
         }
 
         val categoryId = intent.getStringExtra(CONVERTER_ID_EXTRA)
@@ -88,7 +86,9 @@ class ConverterActivity : AppCompatActivity() {
         }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        viewModel.categoryId.value?.let { outState.putString(CONVERTER_ID_EXTRA, it) }
+        viewModel.uiState.value
+            ?.categoryId
+            ?.let { outState.putString(CONVERTER_ID_EXTRA, it) }
         super.onSaveInstanceState(outState)
     }
 

--- a/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
@@ -1,5 +1,7 @@
 package dev.nevack.unitconverter.converter
 
+import dev.nevack.unitconverter.model.converter.Converter
+
 data class ConvertData(
     val value: String,
     val result: String,
@@ -18,3 +20,12 @@ sealed class Result(
         result: String,
     ) : Result(result)
 }
+
+data class ConverterUiState(
+    val drawerOpened: Boolean = false,
+    val backgroundColor: Int? = null,
+    val title: Int? = null,
+    val categoryId: String? = null,
+    val converter: Converter? = null,
+    val result: Result = Result.Empty,
+)

--- a/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
@@ -86,20 +86,29 @@ class ConverterFragment : Fragment(R.layout.fragment_converter) {
         }
         binding.keypad.setNumericListener { binding.display.appendText(it) }
 
-        viewModel.backgroundColor.observe(viewLifecycleOwner) {
-            binding.background.setBackgroundColor(ContextCompat.getColor(requireContext(), it))
-        }
+        var previousState: ConverterUiState? = null
+        viewModel.uiState.observe(viewLifecycleOwner) { state ->
+            val oldState = previousState
 
-        viewModel.title.observe(viewLifecycleOwner) {
-            binding.toolbar.setTitle(it)
-        }
+            if (state.backgroundColor != oldState?.backgroundColor) {
+                state.backgroundColor?.let {
+                    binding.background.setBackgroundColor(ContextCompat.getColor(requireContext(), it))
+                }
+            }
 
-        viewModel.converter.observe(viewLifecycleOwner) {
-            binding.display.setUnits(it.units)
-        }
+            if (state.title != oldState?.title) {
+                state.title?.let(binding.toolbar::setTitle)
+            }
 
-        viewModel.result.observe(viewLifecycleOwner) {
-            binding.display.showResult(it.result)
+            if (state.converter !== oldState?.converter) {
+                state.converter?.let { binding.display.setUnits(it.units) }
+            }
+
+            if (state.result != oldState?.result) {
+                binding.display.showResult(state.result.result)
+            }
+
+            previousState = state
         }
     }
 

--- a/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
@@ -9,7 +9,6 @@ import dev.nevack.unitconverter.history.HistoryRecord
 import dev.nevack.unitconverter.history.db.HistoryDatabase
 import dev.nevack.unitconverter.history.db.toEntity
 import dev.nevack.unitconverter.model.AppConverterCatalog
-import dev.nevack.unitconverter.model.converter.Converter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -21,55 +20,40 @@ class ConverterViewModel
         private val database: HistoryDatabase,
         private val catalog: AppConverterCatalog,
     ) : ViewModel() {
-        private val _drawerOpened = MutableLiveData(false)
-        val drawerOpened: LiveData<Boolean>
-            get() = _drawerOpened
-
-        private val _backgroundColor = MutableLiveData<Int>()
-        val backgroundColor: LiveData<Int>
-            get() = _backgroundColor
-
-        private val _title = MutableLiveData<Int>()
-        val title: LiveData<Int>
-            get() = _title
-
-        private val _categoryId = MutableLiveData<String>()
-        val categoryId: LiveData<String>
-            get() = _categoryId
-
-        private val _converter = MutableLiveData<Converter>()
-        val converter: LiveData<Converter>
-            get() = _converter
-
-        private val _result = MutableLiveData<Result>()
-        val result: LiveData<Result>
-            get() = _result
+        private val _uiState = MutableLiveData(ConverterUiState())
+        val uiState: LiveData<ConverterUiState>
+            get() = _uiState
 
         fun setDrawerOpened(opened: Boolean): Boolean {
-            val changed = _drawerOpened.value != opened
-            _drawerOpened.value = opened
+            val changed = _uiState.value?.drawerOpened != opened
+            updateUiState { copy(drawerOpened = opened) }
             return changed
         }
 
         fun load(categoryId: String) {
             val category = catalog.getCategory(categoryId) ?: return
-            _title.value = category.categoryName
-            _backgroundColor.value = category.color
-
-            _categoryId.value = category.id
-
             val converter = catalog.createConverter(categoryId)
+
+            updateUiState {
+                copy(
+                    title = category.categoryName,
+                    backgroundColor = category.color,
+                    categoryId = category.id,
+                    converter = null,
+                    result = Result.Empty,
+                )
+            }
 
             viewModelScope.launch {
                 converter.load()
-                _converter.value = converter
+                updateUiState { copy(converter = converter) }
             }
         }
 
         fun convert(data: ConvertData) {
-            val converter = converter.value
+            val converter = uiState.value?.converter
             if (converter == null) {
-                _result.value = Result.Empty
+                updateUiState { copy(result = Result.Empty) }
                 return
             }
             try {
@@ -81,15 +65,16 @@ class ConverterViewModel
                             data.to,
                         ),
                     )
-                _result.value = result
+                updateUiState { copy(result = result) }
             } catch (ex: Exception) {
-                _result.value = Result.Empty
+                updateUiState { copy(result = Result.Empty) }
             }
         }
 
         fun saveResultToHistory(result: ConvertData) {
-            val converter = converter.value ?: return
-            val categoryId = _categoryId.value ?: return
+            val uiState = _uiState.value ?: return
+            val converter = uiState.converter ?: return
+            val categoryId = uiState.categoryId ?: return
             val item =
                 HistoryRecord(
                     unitFrom = converter[result.from].name,
@@ -101,5 +86,9 @@ class ConverterViewModel
             viewModelScope.launch(Dispatchers.IO) {
                 database.dao().insertAll(item.toEntity())
             }
+        }
+
+        private inline fun updateUiState(update: ConverterUiState.() -> ConverterUiState) {
+            _uiState.value = update(_uiState.value ?: ConverterUiState())
         }
     }


### PR DESCRIPTION
Keep the converter screen driven by one source of truth so related UI updates stay in sync and category switches cannot reuse stale converter data.
