### PR TITLE
Improve coroutine correctness in converter and history flows

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation("androidx.drawerlayout:drawerlayout:1.2.0")
     // Room
     implementation("androidx.room:room-common:2.8.4")
+    implementation("androidx.room:room-ktx:2.8.4")
     implementation("androidx.room:room-runtime:2.8.4")
     ksp("androidx.room:room-compiler:2.8.4")
     implementation("androidx.sqlite:sqlite:2.6.2")

--- a/app/src/main/kotlin/dev/nevack/unitconverter/categories/CategoriesActivity.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/categories/CategoriesActivity.kt
@@ -48,7 +48,7 @@ class CategoriesActivity : AppCompatActivity() {
             }
         }
 
-        if (isTablet) {
+        if (isTablet && converterViewModel.uiState.value?.categoryId == null) {
             categories.firstOrNull()?.let { category ->
                 converterViewModel.load(category.id)
             }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
@@ -62,9 +62,11 @@ class ConverterActivity : AppCompatActivity() {
             replace<ConverterFragment>(R.id.container, args = bundleOf(SHOW_NAV_BUTTON_ARG to true))
         }
 
-        val categoryId = intent.getStringExtra(CONVERTER_ID_EXTRA)
-        val initialCategoryId = categoryId ?: categories.firstOrNull()?.id ?: return
-        viewModel.load(initialCategoryId)
+        if (viewModel.uiState.value?.categoryId == null) {
+            val categoryId = intent.getStringExtra(CONVERTER_ID_EXTRA)
+            val initialCategoryId = categoryId ?: categories.firstOrNull()?.id ?: return
+            viewModel.load(initialCategoryId)
+        }
     }
 
     private fun setupNavigation(
@@ -86,21 +88,6 @@ class ConverterActivity : AppCompatActivity() {
         applyInsetter {
             type(statusBars = true) { margin(top = true) }
             type(navigationBars = true) { margin(bottom = true) }
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        viewModel.uiState.value
-            ?.categoryId
-            ?.let { outState.putString(CONVERTER_ID_EXTRA, it) }
-        super.onSaveInstanceState(outState)
-    }
-
-    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
-        super.onRestoreInstanceState(savedInstanceState)
-        val categoryId = savedInstanceState.getString(CONVERTER_ID_EXTRA)
-        if (categoryId != null) {
-            viewModel.load(categoryId)
         }
     }
 

--- a/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
@@ -27,5 +27,8 @@ data class ConverterUiState(
     val title: Int? = null,
     val categoryId: String? = null,
     val converter: Converter? = null,
+    val isLoading: Boolean = false,
+    val currentInput: ConvertData? = null,
+    val messageResId: Int? = null,
     val result: Result = Result.Empty,
 )

--- a/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
@@ -108,6 +108,11 @@ class ConverterFragment : Fragment(R.layout.fragment_converter) {
                 binding.display.showResult(state.result.result)
             }
 
+            if (state.messageResId != null && state.messageResId != oldState?.messageResId) {
+                Snackbar.make(binding.root, state.messageResId, Snackbar.LENGTH_SHORT).show()
+                viewModel.clearMessage()
+            }
+
             previousState = state
         }
     }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.nevack.unitconverter.R
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -17,6 +20,7 @@ class ConverterViewModel
         private val convertValueUseCase: ConvertValueUseCase,
         private val saveResultToHistoryUseCase: SaveResultToHistoryUseCase,
     ) : ViewModel() {
+        private var loadJob: Job? = null
         private val _uiState = MutableLiveData(ConverterUiState())
         val uiState: LiveData<ConverterUiState>
             get() = _uiState
@@ -30,26 +34,74 @@ class ConverterViewModel
         fun load(categoryId: String) {
             val category = getConverterCategoryUseCase(categoryId) ?: return
 
+            loadJob?.cancel()
+
             updateUiState {
                 copy(
                     title = category.categoryName,
                     backgroundColor = category.color,
                     categoryId = category.id,
                     converter = null,
+                    isLoading = true,
+                    currentInput = null,
+                    messageResId = null,
                     result = Result.Empty,
                 )
             }
 
-            viewModelScope.launch {
-                val converter = loadConverterUseCase(categoryId) ?: return@launch
-                updateUiState { copy(converter = converter) }
-            }
+            loadJob =
+                viewModelScope.launch {
+                    try {
+                        val converter = loadConverterUseCase(categoryId) ?: return@launch
+                        val currentInput = uiState.value?.currentInput
+                        val result =
+                            currentInput
+                                ?.let { convertValueUseCase(converter, it) }
+                                ?.let { Result.Converted(it) }
+                                ?: Result.Empty
+                        updateUiState {
+                            if (this.categoryId != categoryId) {
+                                this
+                            } else {
+                                copy(
+                                    converter = converter,
+                                    isLoading = false,
+                                    result = result,
+                                )
+                            }
+                        }
+                    } catch (ignored: CancellationException) {
+                        throw ignored
+                    } catch (ignored: Exception) {
+                        updateUiState {
+                            if (this.categoryId != categoryId) {
+                                this
+                            } else {
+                                copy(
+                                    isLoading = false,
+                                    messageResId = R.string.failed_to_load_converter,
+                                )
+                            }
+                        }
+                    }
+                }
+        }
+
+        fun clearMessage() {
+            updateUiState { copy(messageResId = null) }
+        }
+
+        override fun onCleared() {
+            loadJob?.cancel()
+            super.onCleared()
         }
 
         fun convert(data: ConvertData) {
-            val result = convertValueUseCase(uiState.value?.converter, data)
+            val currentState = uiState.value ?: ConverterUiState()
+            val result = convertValueUseCase(currentState.converter, data)
             updateUiState {
                 copy(
+                    currentInput = data,
                     result = result?.let { Result.Converted(it) } ?: Result.Empty,
                 )
             }
@@ -60,7 +112,13 @@ class ConverterViewModel
             val converter = uiState.converter ?: return
             val categoryId = uiState.categoryId ?: return
             viewModelScope.launch {
-                saveResultToHistoryUseCase(converter, categoryId, result)
+                try {
+                    saveResultToHistoryUseCase(converter, categoryId, result)
+                } catch (ignored: CancellationException) {
+                    throw ignored
+                } catch (ignored: Exception) {
+                    updateUiState { copy(messageResId = R.string.failed_to_save_history) }
+                }
             }
         }
 

--- a/app/src/main/kotlin/dev/nevack/unitconverter/history/GetHistoryUseCase.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/history/GetHistoryUseCase.kt
@@ -1,5 +1,6 @@
 package dev.nevack.unitconverter.history
 
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetHistoryUseCase
@@ -7,5 +8,5 @@ class GetHistoryUseCase
     constructor(
         private val historyRepository: HistoryRepository,
     ) {
-        suspend operator fun invoke(): List<HistoryRecord> = historyRepository.getAll()
+        operator fun invoke(): Flow<List<HistoryRecord>> = historyRepository.getAll()
     }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/history/HistoryFragment.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/history/HistoryFragment.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import dev.chrisbanes.insetter.applyInsetter
 import dev.nevack.unitconverter.R
@@ -72,6 +73,12 @@ class HistoryFragment :
         viewModel.items.observe(viewLifecycleOwner) {
             adapter.submitList(it)
             binding.recycler.isInvisible = it.isEmpty()
+        }
+        viewModel.messageResId.observe(viewLifecycleOwner) { messageResId ->
+            if (messageResId != null) {
+                Snackbar.make(binding.root, messageResId, Snackbar.LENGTH_SHORT).show()
+                viewModel.clearMessage()
+            }
         }
 
         val menuHost: MenuHost = requireActivity()

--- a/app/src/main/kotlin/dev/nevack/unitconverter/history/HistoryViewModel.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/history/HistoryViewModel.kt
@@ -1,11 +1,16 @@
 package dev.nevack.unitconverter.history
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.nevack.unitconverter.R
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -17,35 +22,48 @@ class HistoryViewModel
         private val removeHistoryItemUseCase: RemoveHistoryItemUseCase,
         private val clearHistoryUseCase: ClearHistoryUseCase,
     ) : ViewModel() {
-        private val itemsRaw = MutableLiveData<List<HistoryRecord>>().also { fetch() }
-        private var filter = MutableLiveData<String?>(null)
-        private val itemsFiltered by lazy {
-            MediatorLiveData<List<HistoryRecord>>().apply {
-                addSource(filter) { categoryId ->
-                    value = itemsRaw.value?.filter { item ->
-                        categoryId == null || item.categoryId == categoryId
-                    } ?: emptyList()
-                }
-                addSource(itemsRaw) {
-                    val categoryId = filter.value
-                    value = it.filter { item -> categoryId == null || item.categoryId == categoryId }
-                }
+        private val filter = MutableStateFlow<String?>(null)
+        private val _items = MutableLiveData<List<HistoryRecord>>(emptyList())
+        val items: LiveData<List<HistoryRecord>>
+            get() = _items
+
+        private val _messageResId = MutableLiveData<Int?>(null)
+        val messageResId: LiveData<Int?>
+            get() = _messageResId
+
+        init {
+            viewModelScope.launch {
+                getHistoryUseCase()
+                    .combine(filter) { items, categoryId ->
+                        items.filter { item -> categoryId == null || item.categoryId == categoryId }
+                    }.catch {
+                        _messageResId.value = R.string.failed_to_load_history
+                        emit(emptyList())
+                    }.collect { _items.value = it }
             }
         }
-        val items: LiveData<List<HistoryRecord>>
-            get() = itemsFiltered
 
         fun removeItem(item: HistoryRecord) {
             viewModelScope.launch {
-                removeHistoryItemUseCase(item)
-                refreshItems()
+                try {
+                    removeHistoryItemUseCase(item)
+                } catch (ignored: CancellationException) {
+                    throw ignored
+                } catch (ignored: Exception) {
+                    _messageResId.value = R.string.failed_to_update_history
+                }
             }
         }
 
         fun removeAll() {
             viewModelScope.launch {
-                clearHistoryUseCase()
-                refreshItems()
+                try {
+                    clearHistoryUseCase()
+                } catch (ignored: CancellationException) {
+                    throw ignored
+                } catch (ignored: Exception) {
+                    _messageResId.value = R.string.failed_to_update_history
+                }
             }
         }
 
@@ -53,13 +71,7 @@ class HistoryViewModel
             filter.value = categoryId
         }
 
-        private fun fetch() {
-            viewModelScope.launch {
-                refreshItems()
-            }
-        }
-
-        private suspend fun refreshItems() {
-            itemsRaw.postValue(getHistoryUseCase())
+        fun clearMessage() {
+            _messageResId.value = null
         }
     }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/history/RoomHistoryRepository.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/history/RoomHistoryRepository.kt
@@ -3,32 +3,21 @@ package dev.nevack.unitconverter.history
 import dev.nevack.unitconverter.history.db.HistoryDao
 import dev.nevack.unitconverter.history.db.toEntity
 import dev.nevack.unitconverter.history.db.toRecord
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class RoomHistoryRepository(
     private val dao: HistoryDao,
 ) : HistoryRepository {
-    override suspend fun getAll(): List<HistoryRecord> =
-        withContext(Dispatchers.IO) {
-            dao.getAll().map { it.toRecord() }
-        }
+    override fun getAll(): Flow<List<HistoryRecord>> = dao.getAll().map { items -> items.map { it.toRecord() } }
 
     override suspend fun save(record: HistoryRecord) {
-        withContext(Dispatchers.IO) {
-            dao.insertAll(record.toEntity())
-        }
+        dao.insertAll(record.toEntity())
     }
 
     override suspend fun delete(record: HistoryRecord) {
-        withContext(Dispatchers.IO) {
-            dao.delete(record.toEntity())
-        }
+        dao.delete(record.toEntity())
     }
 
-    override suspend fun deleteAll() {
-        withContext(Dispatchers.IO) {
-            dao.deleteAll()
-        }
-    }
+    override suspend fun deleteAll() = dao.deleteAll()
 }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/history/db/HistoryDao.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/history/db/HistoryDao.kt
@@ -4,21 +4,22 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface HistoryDao {
     @Query("SELECT * FROM history")
-    fun getAll(): List<HistoryItem>
+    fun getAll(): Flow<List<HistoryItem>>
 
     @Query("SELECT * FROM history WHERE id IN (:ids)")
     fun loadAllByIds(ids: IntArray): List<HistoryItem>
 
     @Insert
-    fun insertAll(vararg items: HistoryItem)
+    suspend fun insertAll(vararg items: HistoryItem)
 
     @Delete
-    fun delete(item: HistoryItem)
+    suspend fun delete(item: HistoryItem)
 
     @Query("DELETE FROM history")
-    fun deleteAll()
+    suspend fun deleteAll()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,5 +172,9 @@
     <string name="swap_source_and_result_units_and_values">Swap source and result units and values button</string>
     <string name="share_button">Share button</string>
     <string name="remove_item_button">Remove item button</string>
+    <string name="failed_to_load_converter">Failed to load converter data</string>
+    <string name="failed_to_save_history">Failed to save history item</string>
+    <string name="failed_to_load_history">Failed to load history</string>
+    <string name="failed_to_update_history">Failed to update history</string>
 
 </resources>

--- a/converter-core/build.gradle.kts
+++ b/converter-core/build.gradle.kts
@@ -6,6 +6,11 @@ plugins {
 
 kotlin.jvmToolchain(21)
 
+dependencies {
+    implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.2"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+}
+
 spotless {
     val ktlintVersion = "1.8.0"
 

--- a/converter-core/src/main/kotlin/dev/nevack/unitconverter/history/HistoryRepository.kt
+++ b/converter-core/src/main/kotlin/dev/nevack/unitconverter/history/HistoryRepository.kt
@@ -1,7 +1,9 @@
 package dev.nevack.unitconverter.history
 
+import kotlinx.coroutines.flow.Flow
+
 interface HistoryRepository {
-    suspend fun getAll(): List<HistoryRecord>
+    fun getAll(): Flow<List<HistoryRecord>>
 
     suspend fun save(record: HistoryRecord)
 

--- a/nbrb-api/src/main/kotlin/dev/nevack/unitconverter/nbrb/NBRBRepository.kt
+++ b/nbrb-api/src/main/kotlin/dev/nevack/unitconverter/nbrb/NBRBRepository.kt
@@ -6,6 +6,9 @@ import dev.nevack.unitconverter.nbrb.model.NBRBCurrency
 import dev.nevack.unitconverter.nbrb.model.NBRBRate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
@@ -26,52 +29,62 @@ class NBRBRepository(
     private val ratesFile = fileProvider("rates.json")
     private val ratesSerializer = ListSerializer(NBRBRate.serializer())
     private val currenciesSerializer = ListSerializer(NBRBCurrency.serializer())
+    private val loadMutex = Mutex()
 
     override suspend fun getUnits(): List<ConversionUnit> =
-        withContext(Dispatchers.IO) {
-            val currenciesAsync =
-                async {
-                    loadWithCache(currenciesSerializer, currenciesFile) { allCurrencies() }
-                }
-            val ratesAsync =
-                async {
-                    loadWithCache(ratesSerializer, ratesFile) { allRatesForToday() }
-                }
-            val currencies = currenciesAsync.await().associateBy { it.curID }
-            ratesAsync
-                .await()
-                .filter { currencies.containsKey(it.curID) }
-                .map { it.toUnitLocalized(currencies[it.curID]!!.getLocalizedName(locale)) }
+        loadMutex.withLock {
+            coroutineScope {
+                val currenciesAsync =
+                    async {
+                        loadWithCache(currenciesSerializer, currenciesFile) { allCurrencies() }
+                    }
+                val ratesAsync =
+                    async {
+                        loadWithCache(ratesSerializer, ratesFile) { allRatesForToday() }
+                    }
+                val currencies = currenciesAsync.await().associateBy { it.curID }
+                ratesAsync
+                    .await()
+                    .filter { currencies.containsKey(it.curID) }
+                    .map { it.toUnitLocalized(currencies[it.curID]!!.getLocalizedName(locale)) }
+            }
         }
 
     private suspend fun <T> loadWithCache(
         serializer: KSerializer<T>,
         file: File,
         block: suspend NBRBService.() -> T,
-    ): T =
-        withContext(Dispatchers.IO) {
-            if (file.exists()) {
-                val calendar = Calendar.getInstance().apply { timeInMillis = file.lastModified() }
-                if (Calendar.getInstance()[Calendar.DAY_OF_YEAR] == calendar[Calendar.DAY_OF_YEAR]) {
-                    val cached = serializer.load(file)
-                    if (cached != null) {
-                        return@withContext cached
-                    }
+    ): T {
+        val cached =
+            withContext(Dispatchers.IO) {
+                if (!file.exists()) {
+                    return@withContext null
                 }
+                val calendar = Calendar.getInstance().apply { timeInMillis = file.lastModified() }
+                val now = Calendar.getInstance()
+                if (
+                    now[Calendar.YEAR] != calendar[Calendar.YEAR] ||
+                    now[Calendar.DAY_OF_YEAR] != calendar[Calendar.DAY_OF_YEAR]
+                ) {
+                    return@withContext null
+                }
+                serializer.load(file)
             }
-            loadFromWeb(serializer, file, block)
+        if (cached != null) {
+            return cached
         }
+        return loadFromWeb(serializer, file, block)
+    }
 
     private suspend fun <T> loadFromWeb(
         serializer: KSerializer<T>,
         cache: File,
         block: suspend NBRBService.() -> T,
-    ): T =
-        withContext(Dispatchers.IO) {
-            val result = service.block()
-            serializer.save(result to cache)
-            result
-        }
+    ): T {
+        val result = service.block()
+        serializer.save(result to cache)
+        return result
+    }
 
     private suspend fun <T> KSerializer<T>.save(what: Pair<T, File>) =
         withContext(Dispatchers.IO) {


### PR DESCRIPTION
Cancel stale converter loads, surface coroutine failures to the UI, and switch history updates to a reactive Room flow so state stays in sync with database changes.
