### PR TITLE
fix/architecture improvements

### DIFF
--- a/app/src/main/kotlin/dev/nevack/unitconverter/categories/CategoriesActivity.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/categories/CategoriesActivity.kt
@@ -18,13 +18,9 @@ import dev.nevack.unitconverter.converter.ConverterViewModel
 import dev.nevack.unitconverter.databinding.ActivityCategoriesBinding
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class CategoriesActivity : AppCompatActivity() {
-    @Inject
-    lateinit var getCategoriesUseCase: GetCategoriesUseCase
-
     private val categoriesViewModel: CategoriesViewModel by viewModels()
     private val converterViewModel: ConverterViewModel by viewModels()
 
@@ -33,7 +29,6 @@ class CategoriesActivity : AppCompatActivity() {
         val binding = ActivityCategoriesBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setSupportActionBar(binding.toolbar)
-        val categories = getCategoriesUseCase()
 
         val isTablet = binding.converterContainer != null
 
@@ -58,7 +53,7 @@ class CategoriesActivity : AppCompatActivity() {
         }
 
         if (isTablet) {
-            categories.firstOrNull()?.let { category ->
+            categoriesViewModel.categories.firstOrNull()?.let { category ->
                 converterViewModel.load(category.id)
             }
         }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/categories/CategoriesFragment.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/categories/CategoriesFragment.kt
@@ -9,14 +9,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.chrisbanes.insetter.applyInsetter
 import dev.nevack.unitconverter.R
 import dev.nevack.unitconverter.databinding.FragmentCategoriesBinding
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class CategoriesFragment : Fragment(R.layout.fragment_categories) {
     private val viewModel: CategoriesViewModel by activityViewModels()
-
-    @Inject
-    lateinit var getCategoriesUseCase: GetCategoriesUseCase
 
     override fun onViewCreated(
         view: View,
@@ -27,7 +23,7 @@ class CategoriesFragment : Fragment(R.layout.fragment_categories) {
             layoutManager =
                 GridLayoutManager(requireContext(), resources.getInteger(R.integer.column_count))
             setHasFixedSize(true)
-            adapter = CategoriesAdapter(getCategoriesUseCase(), viewModel::openConverter)
+            adapter = CategoriesAdapter(viewModel.categories, viewModel::openConverter)
 
             applyInsetter { type(navigationBars = true) { padding() } }
         }

--- a/app/src/main/kotlin/dev/nevack/unitconverter/categories/CategoriesViewModel.kt
+++ b/app/src/main/kotlin/dev/nevack/unitconverter/categories/CategoriesViewModel.kt
@@ -1,20 +1,30 @@
 package dev.nevack.unitconverter.categories
 
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.nevack.unitconverter.model.AppConverterCategory
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
 
-class CategoriesViewModel : ViewModel() {
-    private val _converterOpened =
-        MutableSharedFlow<String>(
-            extraBufferCapacity = 1,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST,
-        )
-    val converterOpened: SharedFlow<String> = _converterOpened.asSharedFlow()
+@HiltViewModel
+class CategoriesViewModel
+    @Inject
+    constructor(
+        getCategoriesUseCase: GetCategoriesUseCase,
+    ) : ViewModel() {
+        val categories: List<AppConverterCategory> = getCategoriesUseCase()
 
-    fun openConverter(categoryId: String) {
-        _converterOpened.tryEmit(categoryId)
+        private val _converterOpened =
+            MutableSharedFlow<String>(
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
+        val converterOpened: SharedFlow<String> = _converterOpened.asSharedFlow()
+
+        fun openConverter(categoryId: String) {
+            _converterOpened.tryEmit(categoryId)
+        }
     }
-}

--- a/core/converter/src/main/kotlin/dev/nevack/unitconverter/model/converter/MassConverter.kt
+++ b/core/converter/src/main/kotlin/dev/nevack/unitconverter/model/converter/MassConverter.kt
@@ -10,7 +10,7 @@ class MassConverter(
             listOf(
                 UnitDefinition("kilogram", 1.0),
                 UnitDefinition("gram", 0.001),
-                UnitDefinition("milligram", 0.0000001),
+                UnitDefinition("milligram", 0.000001),
                 UnitDefinition("hundredweight", 100.0),
                 UnitDefinition("tonne", 1000.0),
             )

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
@@ -68,9 +68,14 @@ class ConverterActivity : AppCompatActivity() {
             )
         }
 
-        val categoryId = intent.getStringExtra(CONVERTER_ID_EXTRA)
-        val initialCategoryId = categoryId ?: categories.firstOrNull()?.id ?: return
-        viewModel.load(initialCategoryId)
+        // Only load on a fresh launch; SavedStateHandle restores categoryId across
+        // configuration changes and process death automatically.
+        if (savedInstanceState == null) {
+            val categoryId = intent.getStringExtra(CONVERTER_ID_EXTRA)
+                ?: categories.firstOrNull()?.id
+                ?: return
+            viewModel.load(categoryId)
+        }
     }
 
     private fun setupNavigation(
@@ -92,21 +97,6 @@ class ConverterActivity : AppCompatActivity() {
         applyInsetter {
             type(statusBars = true) { margin(top = true) }
             type(navigationBars = true) { margin(bottom = true) }
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        viewModel.uiState.value
-            .categoryId
-            ?.let { outState.putString(CONVERTER_ID_EXTRA, it) }
-        super.onSaveInstanceState(outState)
-    }
-
-    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
-        super.onRestoreInstanceState(savedInstanceState)
-        val categoryId = savedInstanceState.getString(CONVERTER_ID_EXTRA)
-        if (categoryId != null) {
-            viewModel.load(categoryId)
         }
     }
 

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
@@ -16,20 +16,15 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import dev.chrisbanes.insetter.applyInsetter
-import dev.nevack.unitconverter.categories.GetCategoriesUseCase
 import dev.nevack.unitconverter.converter.ConverterFragment.Companion.SHOW_NAV_BUTTON_ARG
 import dev.nevack.unitconverter.feature.converter.R
 import dev.nevack.unitconverter.feature.converter.databinding.ActivityConverterBinding
 import dev.nevack.unitconverter.model.AppConverterCategory
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class ConverterActivity : AppCompatActivity() {
-    @Inject
-    lateinit var getCategoriesUseCase: GetCategoriesUseCase
-
     private val viewModel: ConverterViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,7 +34,7 @@ class ConverterActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        val categories = getCategoriesUseCase()
+        val categories = viewModel.categories
 
         setupNavigation(binding, categories)
 

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
@@ -54,7 +54,10 @@ class ConverterActivity : AppCompatActivity() {
                     val categoryId = state.categoryId ?: return@collect
                     val categoryIndex = categories.indexOfFirst { it.id == categoryId }
                     if (categoryIndex != -1) {
-                        binding.navigationView.menu[categoryIndex].isChecked = true
+                        // findItem uses itemId which we set to the list index, so this is stable.
+                        binding.navigationView.menu
+                            .findItem(categoryIndex)
+                            ?.isChecked = true
                     }
                 }
             }
@@ -71,9 +74,10 @@ class ConverterActivity : AppCompatActivity() {
         // Only load on a fresh launch; SavedStateHandle restores categoryId across
         // configuration changes and process death automatically.
         if (savedInstanceState == null) {
-            val categoryId = intent.getStringExtra(CONVERTER_ID_EXTRA)
-                ?: categories.firstOrNull()?.id
-                ?: return
+            val categoryId =
+                intent.getStringExtra(CONVERTER_ID_EXTRA)
+                    ?: categories.firstOrNull()?.id
+                    ?: return
             viewModel.load(categoryId)
         }
     }
@@ -83,13 +87,15 @@ class ConverterActivity : AppCompatActivity() {
         categories: List<AppConverterCategory>,
     ) = with(binding.navigationView) {
         for ((i, unit) in categories.withIndex()) {
+            // Use the list index as a stable itemId so the listener can look up the category
+            // directly by ID rather than relying on the display order of menu items.
             menu
-                .add(Menu.NONE, Menu.NONE, i, unit.categoryName)
+                .add(Menu.NONE, i, i, unit.categoryName)
                 .setCheckable(true)
                 .setIcon(unit.icon)
         }
         setNavigationItemSelectedListener { menuItem ->
-            val category = categories.getOrNull(menuItem.order) ?: return@setNavigationItemSelectedListener false
+            val category = categories.getOrNull(menuItem.itemId) ?: return@setNavigationItemSelectedListener false
             viewModel.load(category.id)
             viewModel.setDrawerOpened(false)
             true

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
@@ -29,4 +29,5 @@ data class ConverterUiState(
     val converter: Converter? = null,
     val convertData: ConvertData = ConvertData("", "", 0, 1),
     val result: Result = Result.Empty,
+    val loadError: String? = null,
 )

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
@@ -27,5 +27,6 @@ data class ConverterUiState(
     val title: Int? = null,
     val categoryId: String? = null,
     val converter: Converter? = null,
+    val convertData: ConvertData = ConvertData("", "", 0, 1),
     val result: Result = Result.Empty,
 )

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterDisplayView.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterDisplayView.kt
@@ -79,12 +79,14 @@ internal class ConverterDisplayView
                 }
             set(convertData) =
                 with(binding) {
-                    sourceValue.setText(convertData.value)
-                    resultValue.setText(convertData.result)
+                    // Set indices and spinner labels before setText so that doAfterTextChanged
+                    // fires with a fully consistent ConvertData (correct from/to already set).
                     sourceIndex = convertData.from
                     resultIndex = convertData.to
                     sourceSpinner.setText(conversionUnits[sourceIndex].name, false)
                     resultSpinner.setText(conversionUnits[resultIndex].name, false)
+                    resultValue.setText(convertData.result)
+                    sourceValue.setText(convertData.value)
                 }
 
         fun getCopyResult(withUnitSymbols: Boolean): String =

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
@@ -124,6 +124,11 @@ class ConverterFragment : Fragment(R.layout.fragment_converter) {
                         binding.display.showResult(state.result.result)
                     }
 
+                    if (state.loadError != null && state.loadError != oldState?.loadError) {
+                        Snackbar.make(binding.root, state.loadError, Snackbar.LENGTH_LONG).show()
+                        viewModel.clearLoadError()
+                    }
+
                     previousState = state
                 }
             }

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
@@ -41,7 +41,7 @@ class ConverterFragment : Fragment(R.layout.fragment_converter) {
         binding.toolbar.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.save -> {
-                    viewModel.saveResultToHistory(binding.display.convertData)
+                    viewModel.saveResultToHistory()
                     true
                 }
 
@@ -110,7 +110,14 @@ class ConverterFragment : Fragment(R.layout.fragment_converter) {
                     }
 
                     if (state.converter !== oldState?.converter) {
-                        state.converter?.let { binding.display.setUnits(it.units) }
+                        state.converter?.let {
+                            binding.display.setUnits(it.units)
+                            // Restore selected unit indices and input value. On a fresh view
+                            // (rotation or first load), this re-populates what the user had before.
+                            // The convertData setter sets indices before setText so the
+                            // doAfterTextChanged callback fires with a fully consistent state.
+                            binding.display.convertData = state.convertData
+                        }
                     }
 
                     if (state.result != oldState?.result) {

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
@@ -50,6 +50,7 @@ class ConverterViewModel
                     backgroundColor = category.color,
                     categoryId = category.id,
                     converter = null,
+                    convertData = ConvertData("", "", 0, 1),
                     result = Result.Empty,
                 )
             }
@@ -69,20 +70,21 @@ class ConverterViewModel
         }
 
         fun convert(data: ConvertData) {
-            val result = convertValueUseCase(uiState.value.converter, data)
+            val resultString = convertValueUseCase(uiState.value.converter, data)
             updateUiState {
                 copy(
-                    result = result?.let { Result.Converted(it) } ?: Result.Empty,
+                    convertData = data.copy(result = resultString ?: ""),
+                    result = resultString?.let { Result.Converted(it) } ?: Result.Empty,
                 )
             }
         }
 
-        fun saveResultToHistory(result: ConvertData) {
+        fun saveResultToHistory() {
             val uiState = _uiState.value
             val converter = uiState.converter ?: return
             val categoryId = uiState.categoryId ?: return
             viewModelScope.launch {
-                saveResultToHistoryUseCase(converter, categoryId, result)
+                saveResultToHistoryUseCase(converter, categoryId, uiState.convertData)
             }
         }
 

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
@@ -58,14 +58,25 @@ class ConverterViewModel
             loadJob?.cancel()
             loadJob =
                 viewModelScope.launch {
-                    val converter = loadConverterUseCase(categoryId) ?: return@launch
-                    updateUiState {
-                        if (this.categoryId != categoryId) {
-                            this
-                        } else {
-                            copy(converter = converter)
+                    runCatching { loadConverterUseCase(categoryId) }
+                        .onSuccess { converter ->
+                            updateUiState {
+                                if (this.categoryId != categoryId) {
+                                    this
+                                } else {
+                                    copy(converter = converter, loadError = null)
+                                }
+                            }
                         }
-                    }
+                        .onFailure { e ->
+                            updateUiState {
+                                if (this.categoryId != categoryId) {
+                                    this
+                                } else {
+                                    copy(loadError = e.localizedMessage)
+                                }
+                            }
+                        }
                 }
         }
 
@@ -77,6 +88,10 @@ class ConverterViewModel
                     result = resultString?.let { Result.Converted(it) } ?: Result.Empty,
                 )
             }
+        }
+
+        fun clearLoadError() {
+            updateUiState { copy(loadError = null) }
         }
 
         fun saveResultToHistory() {

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
@@ -67,8 +67,7 @@ class ConverterViewModel
                                     copy(converter = converter, loadError = null)
                                 }
                             }
-                        }
-                        .onFailure { e ->
+                        }.onFailure { e ->
                             updateUiState {
                                 if (this.categoryId != categoryId) {
                                     this

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
@@ -3,6 +3,8 @@ package dev.nevack.unitconverter.converter
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.nevack.unitconverter.categories.GetCategoriesUseCase
+import dev.nevack.unitconverter.model.AppConverterCategory
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,11 +17,13 @@ import javax.inject.Inject
 class ConverterViewModel
     @Inject
     constructor(
+        getCategoriesUseCase: GetCategoriesUseCase,
         private val getConverterCategoryUseCase: GetConverterCategoryUseCase,
         private val loadConverterUseCase: LoadConverterUseCase,
         private val convertValueUseCase: ConvertValueUseCase,
         private val saveResultToHistoryUseCase: SaveResultToHistoryUseCase,
     ) : ViewModel() {
+        val categories: List<AppConverterCategory> = getCategoriesUseCase()
         private val _uiState = MutableStateFlow(ConverterUiState())
         val uiState: StateFlow<ConverterUiState> = _uiState.asStateFlow()
         private var loadJob: Job? = null

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
@@ -1,5 +1,6 @@
 package dev.nevack.unitconverter.converter
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,6 +18,7 @@ import javax.inject.Inject
 class ConverterViewModel
     @Inject
     constructor(
+        private val savedState: SavedStateHandle,
         getCategoriesUseCase: GetCategoriesUseCase,
         private val getConverterCategoryUseCase: GetConverterCategoryUseCase,
         private val loadConverterUseCase: LoadConverterUseCase,
@@ -28,6 +30,10 @@ class ConverterViewModel
         val uiState: StateFlow<ConverterUiState> = _uiState.asStateFlow()
         private var loadJob: Job? = null
 
+        init {
+            savedState.get<String>(KEY_CATEGORY_ID)?.let { load(it) }
+        }
+
         fun setDrawerOpened(opened: Boolean): Boolean {
             val changed = _uiState.value.drawerOpened != opened
             updateUiState { copy(drawerOpened = opened) }
@@ -36,6 +42,7 @@ class ConverterViewModel
 
         fun load(categoryId: String) {
             val category = getConverterCategoryUseCase(categoryId) ?: return
+            savedState[KEY_CATEGORY_ID] = categoryId
 
             updateUiState {
                 copy(
@@ -81,5 +88,9 @@ class ConverterViewModel
 
         private inline fun updateUiState(update: ConverterUiState.() -> ConverterUiState) {
             _uiState.update(update)
+        }
+
+        companion object {
+            private const val KEY_CATEGORY_ID = "category_id"
         }
     }

--- a/feature/history/build.gradle.kts
+++ b/feature/history/build.gradle.kts
@@ -8,6 +8,10 @@ android {
     namespace = "dev.nevack.unitconverter.feature.history"
 }
 
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 dependencies {
     implementation(project(":feature:history-api"))
 

--- a/feature/history/schemas/dev.nevack.unitconverter.history.data.db.HistoryDatabase/2.json
+++ b/feature/history/schemas/dev.nevack.unitconverter.history.data.db.HistoryDatabase/2.json
@@ -1,0 +1,61 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "33afb9efcedc7ff041ba5aaaac13e090",
+    "entities": [
+      {
+        "tableName": "history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `unit_from` TEXT NOT NULL, `unit_to` TEXT NOT NULL, `value_from` TEXT NOT NULL, `value_to` TEXT NOT NULL, `category_id` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitFrom",
+            "columnName": "unit_from",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitTo",
+            "columnName": "unit_to",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueFrom",
+            "columnName": "value_from",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueTo",
+            "columnName": "value_to",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '33afb9efcedc7ff041ba5aaaac13e090')"
+    ]
+  }
+}

--- a/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/data/RoomHistoryRepository.kt
+++ b/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/data/RoomHistoryRepository.kt
@@ -5,10 +5,8 @@ import dev.nevack.unitconverter.history.HistoryRepository
 import dev.nevack.unitconverter.history.data.db.HistoryDao
 import dev.nevack.unitconverter.history.data.db.toEntity
 import dev.nevack.unitconverter.history.data.db.toRecord
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 
 class RoomHistoryRepository(
     private val dao: HistoryDao,
@@ -16,20 +14,14 @@ class RoomHistoryRepository(
     override fun observeAll(): Flow<List<HistoryRecord>> = dao.observeAll().map { items -> items.map { it.toRecord() } }
 
     override suspend fun save(record: HistoryRecord) {
-        withContext(Dispatchers.IO) {
-            dao.insertAll(record.toEntity())
-        }
+        dao.insertAll(record.toEntity())
     }
 
     override suspend fun delete(record: HistoryRecord) {
-        withContext(Dispatchers.IO) {
-            dao.delete(record.toEntity())
-        }
+        dao.delete(record.toEntity())
     }
 
     override suspend fun deleteAll() {
-        withContext(Dispatchers.IO) {
-            dao.deleteAll()
-        }
+        dao.deleteAll()
     }
 }

--- a/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/data/db/HistoryDao.kt
+++ b/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/data/db/HistoryDao.kt
@@ -15,11 +15,11 @@ interface HistoryDao {
     fun loadAllByIds(ids: IntArray): List<HistoryItem>
 
     @Insert
-    fun insertAll(vararg items: HistoryItem)
+    suspend fun insertAll(vararg items: HistoryItem)
 
     @Delete
-    fun delete(item: HistoryItem)
+    suspend fun delete(item: HistoryItem)
 
     @Query("DELETE FROM history")
-    fun deleteAll()
+    suspend fun deleteAll()
 }

--- a/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/data/db/HistoryDatabase.kt
+++ b/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/data/db/HistoryDatabase.kt
@@ -3,7 +3,7 @@ package dev.nevack.unitconverter.history.data.db
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [HistoryItem::class], version = 2, exportSchema = false)
+@Database(entities = [HistoryItem::class], version = 2, exportSchema = true)
 abstract class HistoryDatabase : RoomDatabase() {
     abstract fun dao(): HistoryDao
 }

--- a/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/di/HistoryModule.kt
+++ b/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/di/HistoryModule.kt
@@ -9,11 +9,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
 import dev.nevack.unitconverter.history.HistoryRepository
 import dev.nevack.unitconverter.history.data.RoomHistoryRepository
 import dev.nevack.unitconverter.history.data.db.HistoryDao
 import dev.nevack.unitconverter.history.data.db.HistoryDatabase
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/di/HistoryModule.kt
+++ b/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/di/HistoryModule.kt
@@ -9,6 +9,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 import dev.nevack.unitconverter.history.HistoryRepository
 import dev.nevack.unitconverter.history.data.RoomHistoryRepository
 import dev.nevack.unitconverter.history.data.db.HistoryDao
@@ -18,6 +19,7 @@ import dev.nevack.unitconverter.history.data.db.HistoryDatabase
 @InstallIn(SingletonComponent::class)
 object HistoryModule {
     @Provides
+    @Singleton
     fun provideDatabase(
         @ApplicationContext context: Context,
     ): HistoryDatabase =
@@ -27,9 +29,11 @@ object HistoryModule {
             .build()
 
     @Provides
+    @Singleton
     fun provideHistoryDao(database: HistoryDatabase): HistoryDao = database.dao()
 
     @Provides
+    @Singleton
     fun provideHistoryRepository(dao: HistoryDao): HistoryRepository = RoomHistoryRepository(dao)
 
     private val MIGRATION_1_2 =

--- a/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/ui/HistoryFilterDialog.kt
+++ b/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/ui/HistoryFilterDialog.kt
@@ -1,30 +1,59 @@
 package dev.nevack.unitconverter.history.ui
 
 import android.app.Dialog
-import android.content.DialogInterface
 import android.os.Bundle
+import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dev.nevack.unitconverter.history.HistoryCategory
 
-typealias Listener = (String?) -> Unit
-
-class HistoryFilterDialog(
-    private val categories: List<HistoryCategory>,
-    private val listener: Listener,
-) : DialogFragment() {
-    private var categoryId: String? = null
+class HistoryFilterDialog : DialogFragment() {
+    private var selectedCategoryId: String? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val names: MutableList<String> = mutableListOf("None")
-        categories.mapTo(names) { getString(it.nameRes) }
+        selectedCategoryId = savedInstanceState?.getString(KEY_SELECTED_ID)
+
+        val ids = requireArguments().getStringArray(ARG_IDS)!!
+        val nameRes = requireArguments().getIntArray(ARG_NAME_RES)!!
+
+        val names = Array(ids.size + 1) { i ->
+            if (i == 0) getString(android.R.string.cancel).let { "None" } else getString(nameRes[i - 1])
+        }
+
         return MaterialAlertDialogBuilder(requireContext())
-            .setItems(names.toTypedArray()) { _, which -> categoryId = categories.getOrNull(which - 1)?.id }
+            .setItems(names) { _, which ->
+                selectedCategoryId = ids.getOrNull(which - 1)
+            }
             .create()
     }
 
-    override fun onDismiss(dialog: DialogInterface) {
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(KEY_SELECTED_ID, selectedCategoryId)
+    }
+
+    override fun onDismiss(dialog: android.content.DialogInterface) {
         super.onDismiss(dialog)
-        listener(categoryId)
+        parentFragmentManager.setFragmentResult(
+            REQUEST_KEY,
+            bundleOf(KEY_SELECTED_ID to selectedCategoryId),
+        )
+    }
+
+    companion object {
+        const val REQUEST_KEY = "HistoryFilterDialog"
+        const val KEY_SELECTED_ID = "selected_category_id"
+
+        private const val ARG_IDS = "category_ids"
+        private const val ARG_NAME_RES = "category_name_res"
+
+        fun newInstance(categories: List<HistoryCategory>): HistoryFilterDialog =
+            HistoryFilterDialog().apply {
+                arguments =
+                    bundleOf(
+                        ARG_IDS to categories.map { it.id }.toTypedArray(),
+                        ARG_NAME_RES to categories.map { it.nameRes }.toIntArray(),
+                    )
+            }
     }
 }

--- a/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/ui/HistoryFilterDialog.kt
+++ b/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/ui/HistoryFilterDialog.kt
@@ -16,15 +16,15 @@ class HistoryFilterDialog : DialogFragment() {
         val ids = requireArguments().getStringArray(ARG_IDS)!!
         val nameRes = requireArguments().getIntArray(ARG_NAME_RES)!!
 
-        val names = Array(ids.size + 1) { i ->
-            if (i == 0) getString(android.R.string.cancel).let { "None" } else getString(nameRes[i - 1])
-        }
+        val names =
+            Array(ids.size + 1) { i ->
+                if (i == 0) getString(android.R.string.cancel).let { "None" } else getString(nameRes[i - 1])
+            }
 
         return MaterialAlertDialogBuilder(requireContext())
             .setItems(names) { _, which ->
                 selectedCategoryId = ids.getOrNull(which - 1)
-            }
-            .create()
+            }.create()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/ui/HistoryFragment.kt
+++ b/feature/history/src/main/kotlin/dev/nevack/unitconverter/history/ui/HistoryFragment.kt
@@ -85,6 +85,14 @@ class HistoryFragment :
 
         val menuHost: MenuHost = requireActivity()
         menuHost.addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
+
+        childFragmentManager.setFragmentResultListener(
+            HistoryFilterDialog.REQUEST_KEY,
+            viewLifecycleOwner,
+        ) { _, result ->
+            val categoryId = result.getString(HistoryFilterDialog.KEY_SELECTED_ID)
+            viewModel.filter(categoryId)
+        }
     }
 
     override fun onCreateMenu(
@@ -102,7 +110,7 @@ class HistoryFragment :
             }
 
             R.id.filter -> {
-                HistoryFilterDialog(categories, viewModel::filter).show(childFragmentManager, "dialog")
+                HistoryFilterDialog.newInstance(categories).show(childFragmentManager, "dialog")
                 true
             }
 

--- a/nbrb-api/src/main/kotlin/dev/nevack/unitconverter/nbrb/NBRBRepository.kt
+++ b/nbrb-api/src/main/kotlin/dev/nevack/unitconverter/nbrb/NBRBRepository.kt
@@ -4,6 +4,7 @@ import dev.nevack.unitconverter.model.ConversionUnit
 import dev.nevack.unitconverter.model.CurrencyUnitsRepository
 import dev.nevack.unitconverter.nbrb.model.NBRBCurrency
 import dev.nevack.unitconverter.nbrb.model.NBRBRate
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
@@ -89,10 +90,16 @@ class NBRBRepository(
         withContext(Dispatchers.IO) {
             try {
                 json.decodeFromString(this@load, from.readText())
-            } catch (ignored: IOException) {
+            } catch (e: IOException) {
+                Log.w(TAG, "Failed to read cache file ${from.name}", e)
                 null
-            } catch (ignored: SerializationException) {
+            } catch (e: SerializationException) {
+                Log.w(TAG, "Failed to deserialize cache file ${from.name}", e)
                 null
             }
         }
+
+    companion object {
+        private const val TAG = "NBRBRepository"
+    }
 }

--- a/nbrb-api/src/main/kotlin/dev/nevack/unitconverter/nbrb/NBRBRepository.kt
+++ b/nbrb-api/src/main/kotlin/dev/nevack/unitconverter/nbrb/NBRBRepository.kt
@@ -52,7 +52,10 @@ class NBRBRepository(
         withContext(Dispatchers.IO) {
             if (file.exists()) {
                 val calendar = Calendar.getInstance().apply { timeInMillis = file.lastModified() }
-                if (Calendar.getInstance()[Calendar.DAY_OF_YEAR] == calendar[Calendar.DAY_OF_YEAR]) {
+                val today = Calendar.getInstance()
+                if (today[Calendar.YEAR] == calendar[Calendar.YEAR] &&
+                    today[Calendar.DAY_OF_YEAR] == calendar[Calendar.DAY_OF_YEAR]
+                ) {
                     val cached = serializer.load(file)
                     if (cached != null) {
                         return@withContext cached

--- a/nbrb-api/src/main/kotlin/dev/nevack/unitconverter/nbrb/NBRBRepository.kt
+++ b/nbrb-api/src/main/kotlin/dev/nevack/unitconverter/nbrb/NBRBRepository.kt
@@ -1,10 +1,10 @@
 package dev.nevack.unitconverter.nbrb
 
+import android.util.Log
 import dev.nevack.unitconverter.model.ConversionUnit
 import dev.nevack.unitconverter.model.CurrencyUnitsRepository
 import dev.nevack.unitconverter.nbrb.model.NBRBCurrency
 import dev.nevack.unitconverter.nbrb.model.NBRBRate
-import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext


### PR DESCRIPTION
- **Fix milligram conversion factor from 1e-7 to correct 1e-6 kg**
- **Fix currency cache year-boundary bug in same-day freshness check**
- **Make Room DAO write methods suspend, remove manual withContext wrappers**
- **Add @Singleton to HistoryModule providers to make scope explicit**
- **Log cache read/deserialization failures instead of silently swallowing them**
- **Move category list loading into ViewModels, remove direct use-case injection from UI**
- **Use SavedStateHandle in ConverterViewModel to survive process death, remove manual bundle save/restore**
- **Track converter input state in ConverterUiState to survive rotation**
- **Add load error state and Snackbar feedback for currency network failures**
- **Fix HistoryFilterDialog: use Fragment Result API and save selection in Bundle**
- **Enable Room schema export and commit generated schema for HistoryDatabase v2**
- **Fix nav drawer menu to use stable itemId for category lookup instead of order**
