### PR TITLE
Fix drawer reopening when pressing keypad after swipe-close

### DIFF
--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterActivity.kt
@@ -4,11 +4,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
+import android.view.View
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.core.view.get
+import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.lifecycle.Lifecycle
@@ -37,6 +39,23 @@ class ConverterActivity : AppCompatActivity() {
         val categories = viewModel.categories
 
         setupNavigation(binding, categories)
+
+        binding.navigationDrawer.addDrawerListener(
+            object : DrawerLayout.DrawerListener {
+                override fun onDrawerSlide(
+                    drawerView: View,
+                    slideOffset: Float,
+                ) = Unit
+
+                override fun onDrawerOpened(drawerView: View) = Unit
+
+                override fun onDrawerStateChanged(newState: Int) = Unit
+
+                override fun onDrawerClosed(drawerView: View) {
+                    viewModel.setDrawerOpened(false)
+                }
+            },
+        )
 
         val callback =
             onBackPressedDispatcher.addCallback(this) {


### PR DESCRIPTION
When the user closed the drawer via swipe, the DrawerLayout closed
visually but ConverterViewModel.uiState.drawerOpened remained true.
Any subsequent state emission (e.g. from a keypad button triggering
convert()) would re-open the drawer.

Add a DrawerListener that calls viewModel.setDrawerOpened(false) in
onDrawerClosed, keeping the ViewModel in sync with the physical drawer
state regardless of how it was closed.
