### PR TITLE
Show loading indicator while converter data is being fetched

### DIFF
--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterContract.kt
@@ -30,4 +30,5 @@ data class ConverterUiState(
     val convertData: ConvertData = ConvertData("", "", 0, 1),
     val result: Result = Result.Empty,
     val loadError: String? = null,
+    val isLoading: Boolean = false,
 )

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -122,6 +123,11 @@ class ConverterFragment : Fragment(R.layout.fragment_converter) {
 
                     if (state.result != oldState?.result) {
                         binding.display.showResult(state.result.result)
+                    }
+
+                    if (state.isLoading != oldState?.isLoading) {
+                        binding.loadingIndicator.isVisible = state.isLoading
+                        binding.keypad.isEnabled = !state.isLoading
                     }
 
                     if (state.loadError != null && state.loadError != oldState?.loadError) {

--- a/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
+++ b/feature/converter/src/main/kotlin/dev/nevack/unitconverter/converter/ConverterViewModel.kt
@@ -52,6 +52,7 @@ class ConverterViewModel
                     converter = null,
                     convertData = ConvertData("", "", 0, 1),
                     result = Result.Empty,
+                    isLoading = true,
                 )
             }
 
@@ -64,7 +65,7 @@ class ConverterViewModel
                                 if (this.categoryId != categoryId) {
                                     this
                                 } else {
-                                    copy(converter = converter, loadError = null)
+                                    copy(converter = converter, loadError = null, isLoading = false)
                                 }
                             }
                         }.onFailure { e ->
@@ -72,7 +73,7 @@ class ConverterViewModel
                                 if (this.categoryId != categoryId) {
                                     this
                                 } else {
-                                    copy(loadError = e.localizedMessage)
+                                    copy(loadError = e.localizedMessage, isLoading = false)
                                 }
                             }
                         }

--- a/feature/converter/src/main/res/layout-land/fragment_converter.xml
+++ b/feature/converter/src/main/res/layout-land/fragment_converter.xml
@@ -30,6 +30,13 @@
 
         </com.google.android.material.appbar.AppBarLayout>
 
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/loading_indicator"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:visibility="gone" />
+
         <dev.nevack.unitconverter.converter.ConverterDisplayView
             android:id="@+id/display"
             android:layout_width="match_parent"

--- a/feature/converter/src/main/res/layout/fragment_converter.xml
+++ b/feature/converter/src/main/res/layout/fragment_converter.xml
@@ -24,6 +24,13 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/loading_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone" />
+
     <dev.nevack.unitconverter.converter.ConverterDisplayView
         android:id="@+id/display"
         android:layout_width="match_parent"


### PR DESCRIPTION
Add isLoading state to ConverterUiState, set it in ConverterViewModel.load()
on start and clear on success or failure. Display a LinearProgressIndicator
below the toolbar and disable the keypad while loading is in progress.
